### PR TITLE
Recipients and disputes API

### DIFF
--- a/omise/__init__.py
+++ b/omise/__init__.py
@@ -46,10 +46,12 @@ logger = logging.getLogger(__name__)
 __all__ = [
     'Account',
     'Balance',
+    'BankAccount',
     'Card',
     'Charge',
     'Collection',
     'Customer',
+    'Recipient',
     'Refund',
     'Token',
     'Transaction',
@@ -70,10 +72,12 @@ def _get_class_for(type):
     return {
         'account': Account,
         'balance': Balance,
+        'bank_account': BankAccount,
         'token': Token,
         'card': Card,
         'charge': Charge,
         'customer': Customer,
+        'recipient': Recipient,
         'refund': Refund,
         'transfer': Transfer,
         'transaction': Transaction,
@@ -373,6 +377,32 @@ class Balance(_MainResource, Base):
         :rtype: Balance
         """
         return self._reload_data(self._request('get', self._instance_path()))
+
+
+class BankAccount(Base):
+    """API class representing bank account details.
+
+    This API class represents a bank account information returned from other
+    APIs. Bank accounts are not created directly with this class, but instead
+    created with :class:`Recipient`.
+
+    Basic usage::
+
+        >>> import omise
+        >>> omise.api_secret = 'skey_test_4xs8breq3htbkj03d2x'
+        >>> recipient = omise.Recipient.retrieve('recp_test_5086xmr74vxs0ajpo78')
+        >>> bank_account = recipient.bank_account
+        <BankAccount name='SOMCHAI PRASERT' at 0x7f79c41e9d00>
+        >>> bank_account.name
+        'SOMCHAI PRASERT'
+    """
+
+    def __repr__(self):
+        name = self._attributes.get('name')
+        return '<%s%s at %s>' % (
+            type(self).__name__,
+            ' name=%s' % repr(str(name)) if name else '',
+            hex(id(self)))
 
 
 class Token(_VaultResource, Base):
@@ -841,6 +871,124 @@ class Customer(_MainResource, Base):
         :rtype: bool
         """
         return self._attributes.get('deleted', False)
+
+
+class Recipient(_MainResource, Base):
+    """API class representing a recipient in an account.
+
+    This API class is used for retrieving and creating a recipient in an
+    account. The recipient can be used to transfer the balance to specific
+    bank accounts.
+
+    Basic usage::
+
+        >>> import omise
+        >>> omise.api_secret = 'skey_test_4xs8breq3htbkj03d2x'
+        >>> recipient = omise.Recipient.retrieve('recp_test_5086xmr74vxs0ajpo78')
+        <Recipient id='recp_test_5086xmr74vxs0ajpo78' at 0x7f79c41e9eb8>
+        >>> recipient.name
+        'Foobar Baz'
+    """
+
+    @classmethod
+    def _collection_path(cls):
+        return 'recipients'
+
+    @classmethod
+    def _instance_path(cls, recipient_id):
+        return ('recipients', recipient_id)
+
+    @classmethod
+    def create(cls, **kwargs):
+        """Create a recipient with the given parameters.
+
+        See the `create a recipient`_ section in the API documentation for list
+        of available arguments.
+
+        Basic usage::
+
+            >>> import omise
+            >>> omise.api_secret = 'skey_test_4xsjvwfnvb2g0l81sjz'
+            >>> customer = omise.Recipient.create(
+            ...     name='Somchai Prasert',
+            ...     email='somchai.prasert@example.com',
+            ...     type='individual',
+            ...     bank_account=dict(
+            ...       brand='bbl',
+            ...       number='1234567890',
+            ...       name='SOMCHAI PRASERT'
+            ...     )
+            ... )
+            <Recipient id='recp_test_5086xmr74vxs0ajpo78' at 0x7f79c41e9e90>
+
+        .. _create a recipient:
+        ..     https://docs.omise.co/api/recipients/#recipients-create
+
+        :param \*\*kwargs: arguments to create a recipient.
+        :rtype: Recipient
+        """
+        return _as_object(
+            cls._request('post',
+                         cls._collection_path(),
+                         kwargs))
+
+    @classmethod
+    def retrieve(cls, recipient_id=None):
+        """Retrieve the recipient details for the given :param:`recipient_id`.
+        If :param:`recipient_id` is not given, all recipients will be returned
+        instead.
+
+        :param recipient_id: (optional) a recipient id to retrieve.
+        :type recipient_id: str
+        :rtype: Recipient
+        """
+        if recipient_id:
+            return _as_object(cls._request('get',
+                                           cls._instance_path(recipient_id)))
+        return _as_object(cls._request('get', cls._collection_path()))
+
+    def reload(self):
+        """Reload the recipient details.
+
+        :rtype: Recipient
+        """
+        return self._reload_data(
+            self._request('get',
+                          self._instance_path(self._attributes['id'])))
+
+    def update(self, **kwargs):
+        """Update the recipient details with the given arguments.
+
+        See the `update a recipient`_ section in the API documentation for list
+        of available arguments.
+
+        Basic usage::
+
+            >>> import omise
+            >>> omise.api_secret = 'skey_test_4xsjvwfnvb2g0l81sjz'
+            >>> recp = omise.Recipient.retrieve('recp_test_5086xmr74vxs0ajpo78')
+            >>> recp.update(
+            ...     email='somchai@prasert.com',
+            ...     bank_account=dict(
+            ...       brand='kbank',
+            ...       number='1234567890',
+            ...       name='SOMCHAI PRASERT'
+            ...     )
+            ... )
+            <Recipient id='recp_test_5086xmr74vxs0ajpo78' at 0x7f79c41e9d00>
+
+        :param \*\*kwargs: arguments to update a recipient.
+        :rtype: Recipient
+
+        .. _update a recipient:
+        ..     https://docs.omise.co/api/recipients/#recipients-update
+        """
+        changed = copy.deepcopy(self.changes)
+        changed.update(kwargs)
+        return self._reload_data(
+            self._request('patch',
+                          self._instance_path(self._attributes['id']),
+                          changed))
 
 
 class Refund(_MainResource, Base):

--- a/omise/__init__.py
+++ b/omise/__init__.py
@@ -1,4 +1,5 @@
 import copy
+import json
 import logging
 import os
 import requests
@@ -182,12 +183,13 @@ class Request(object):
     def _build_payload(self, payload):
         if payload is None:
             payload = {}
-        return payload
+        return json.dumps(payload)
 
     def _build_headers(self, headers):
         if headers is None:
             headers = {}
         headers['Accept'] = 'application/json'
+        headers['Content-Type'] = 'application/json'
         headers['User-Agent'] = 'OmisePython/%s OmiseAPI/%s' % (
             version.__VERSION__,
             api_compat)

--- a/omise/__init__.py
+++ b/omise/__init__.py
@@ -56,6 +56,7 @@ __all__ = [
     'Charge',
     'Collection',
     'Customer',
+    'Dispute',
     'Recipient',
     'Refund',
     'Token',
@@ -82,6 +83,7 @@ def _get_class_for(type):
         'card': Card,
         'charge': Charge,
         'customer': Customer,
+        'dispute': Dispute,
         'recipient': Recipient,
         'refund': Refund,
         'transfer': Transfer,
@@ -874,6 +876,79 @@ class Customer(_MainResource, Base):
         :rtype: bool
         """
         return self._attributes.get('deleted', False)
+
+
+class Dispute(_MainResource, Base):
+    """API class representing a recipient in an account.
+
+    This API class is used for retrieving and updating a dispute in an
+    account for charge back handling.
+
+    Basic usage::
+
+        >>> import omise
+        >>> omise.api_secret = 'skey_test_4xs8breq3htbkj03d2x'
+        >>> dispute = omise.Dispute.retrieve('dspt_test_4zgf15h89w8t775kcm8')
+        <Recipient id='dspt_test_4zgf15h89w8t775kcm8' at 0x7fd06ce3d5d0>
+        >>> dispute.status
+        'open'
+    """
+
+    @classmethod
+    def _collection_path(cls, status=None):
+        if status:
+            return ('disputes', status)
+        return 'disputes'
+
+    @classmethod
+    def _instance_path(cls, dispute_id):
+        return ('disputes', dispute_id)
+
+    @classmethod
+    def retrieve(cls, *args, **kwargs):
+        if len(args) > 0:
+            return _as_object(cls._request('get', cls._instance_path(args[0])))
+        elif 'status' in kwargs:
+            return _as_object(
+                cls._request('get',
+                             cls._collection_path(kwargs['status'])))
+        return _as_object(cls._request('get', cls._collection_path()))
+
+    def reload(self):
+        """Reload the dispute details.
+
+        :rtype: Dispute
+        """
+        return self._reload_data(
+            self._request('get',
+                          self._instance_path(self._attributes['id'])))
+
+    def update(self, **kwargs):
+        """Update the dispute details with the given arguments.
+
+        See the `update a dispute`_ section in the API documentation for list
+        of available arguments.
+
+        Basic usage::
+
+            >>> import omise
+            >>> omise.api_secret = 'skey_test_4xs8breq3htbkj03d2x'
+            >>> dspt = omise.Dispute.retrieve('dspt_test_4zgf15h89w8t775kcm8')
+            >>> dspt.update(message='Proofs and other information')
+            <Dispute id='dspt_test_4zgf15h89w8t775kcm8' at 0x7fd06cd56210>
+
+        :param \*\*kwargs: arguments to update a dispute.
+        :rtype: Recipient
+
+        .. _update a dispute:
+        ..     https://docs.omise.co/api/recipients/#disputes-update
+        """
+        changed = copy.deepcopy(self.changes)
+        changed.update(kwargs)
+        return self._reload_data(
+            self._request('patch',
+                          self._instance_path(self._attributes['id']),
+                          changed))
 
 
 class Recipient(_MainResource, Base):

--- a/omise/__init__.py
+++ b/omise/__init__.py
@@ -1,5 +1,4 @@
 import copy
-import json
 import logging
 import os
 import requests
@@ -25,6 +24,12 @@ try:
     basestring
 except NameError:
     basestring = str
+
+
+try:
+    import json
+except ImportError:
+    import simplejson as json
 
 
 # Settings
@@ -466,9 +471,7 @@ class Token(_VaultResource, Base):
         :param \*\*kwargs: arguments to create a token.
         :rtype: Token
         """
-        transformed_args = {}
-        for key, value in iteritems(kwargs):
-            transformed_args['card[%s]' % key] = value
+        transformed_args = dict(card=kwargs)
         return _as_object(
             cls._request('post',
                          cls._collection_path(),
@@ -989,6 +992,33 @@ class Recipient(_MainResource, Base):
             self._request('patch',
                           self._instance_path(self._attributes['id']),
                           changed))
+
+    def destroy(self):
+        """Delete the recipient from the server.
+
+        Basic usage::
+
+            >>> import omise
+            >>> omise.api_secret = 'skey_test_4xsjvwfnvb2g0l81sjz'
+            >>> recp = omise.Recipient.retrieve('recp_test_5086xmr74vxs0ajpo78')
+            >>> recp.destroy()
+            <Recipient id='recp_test_5086xmr74vxs0ajpo78' at 0x7f775ff01c60>
+            >>> recp.destroyed
+            True
+
+        :rtype: Recipient
+        """
+        return self._reload_data(
+            self._request('delete',
+                          self._instance_path(self.id)))
+
+    @property
+    def destroyed(self):
+        """Returns ``True`` if the recipient has been deleted.
+
+        :rtype: bool
+        """
+        return self._attributes.get('deleted', False)
 
 
 class Refund(_MainResource, Base):

--- a/omise/errors.py
+++ b/omise/errors.py
@@ -9,6 +9,7 @@ __all__ = [
     'FailedCaptureError',
     'FailedFraudCheckError',
     'FailedRefundError',
+    'InvalidRecipientError',
 ]
 
 
@@ -31,6 +32,7 @@ def _get_error_for(type):
         'failed_capture': FailedCaptureError,
         'failed_fraud_check': FailedFraudCheckError,
         'failed_refund': FailedRefundError,
+        'invalid_recipient': InvalidRecipientError,
     }.get(type)
 
 
@@ -85,6 +87,10 @@ class FailedCaptureError(BaseError):
 
 
 class FailedFraudCheckError(BaseError):
+    pass
+
+
+class InvalidRecipientError(BaseError):
     pass
 
 

--- a/omise/test/__init__.py
+++ b/omise/test/__init__.py
@@ -40,7 +40,7 @@ class _RequestAssertable(object):
             data = {}
         api_call.assert_called_with(
             url,
-            data=data,
+            data=json.dumps(data),
             headers=mock.ANY,
             auth=mock.ANY,
             verify=mock.ANY)
@@ -273,13 +273,15 @@ class TokenTest(_ResourceMixin):
         self.assertEqual(token.card.id, 'card_test')
         self.assertEqual(token.card.last_digits, '4242')
         self.assertRequest(api_call, 'https://vault.omise.co/tokens', {
-            'card[name]': 'Somchai Prasert',
-            'card[number]': '4242424242424242',
-            'card[expiration_month]': 10,
-            'card[expiration_year]': 2018,
-            'card[city]': 'Bangkok',
-            'card[postal_code]': '10320',
-            'card[security_code]': 123
+            'card': {
+                'name': 'Somchai Prasert',
+                'number': '4242424242424242',
+                'expiration_month': 10,
+                'expiration_year': 2018,
+                'city': 'Bangkok',
+                'postal_code': '10320',
+                'security_code': 123
+            }
         })
 
     @mock.patch('requests.get')
@@ -349,6 +351,7 @@ class TokenTest(_ResourceMixin):
         self.assertEqual(token.id, 'tokn_test')
         self.assertTrue(token.used)
         self.assertRequest(api_call, 'https://vault.omise.co/tokens/tokn_test')
+
 
 class CardTest(_ResourceMixin):
 
@@ -1421,6 +1424,288 @@ class CustomerTest(_ResourceMixin):
         customer.destroy()
         self.assertTrue(customer.destroyed)
         self.assertRequest(api_call, 'https://api.omise.co/customers/cust_test')
+
+
+class RecipientTest(_ResourceMixin):
+
+    def _getTargetClass(self):
+        from .. import Recipient
+        return Recipient
+
+    def _getCollectionClass(self):
+        from .. import Collection
+        return Collection
+
+    def _getBankAccountClass(self):
+        from .. import BankAccount
+        return BankAccount
+
+    def _makeOne(self):
+        return self._getTargetClass().from_data({
+            'object': 'recipient',
+            'id': 'recp_test',
+            'livemode': False,
+            'location': '/recipients/recp_test',
+            'verified': False,
+            'active': False,
+            'name': 'James Smith',
+            'email': 'secondary@recipient.co',
+            'description': 'Secondary recipient',
+            'type': 'individual',
+            'tax_id': '1234567890',
+            'bank_account': {
+                'object': 'bank_account',
+                'brand': 'test',
+                'last_digits': '2345',
+                'name': 'James Smith',
+                'created': '2015-06-02T05:41:53Z'
+            },
+            'failure_code': None,
+            'created': "2015-06-02T05:41:53Z"
+        })
+
+    @mock.patch('requests.post')
+    def test_create(self, api_call):
+        class_ = self._getTargetClass()
+        self.mockResponse(api_call, """{
+            "object": "recipient",
+            "id": "recp_test",
+            "livemode": false,
+            "location": "/recipients/recp_test",
+            "verified": false,
+            "active": false,
+            "name": "James Smith",
+            "email": "secondary@recipient.co",
+            "description": "Secondary recipient",
+            "type": "individual",
+            "tax_id": "1234567890",
+            "bank_account": {
+                "object": "bank_account",
+                "brand": "test",
+                "last_digits": "2345",
+                "name": "James Smith",
+                "created": "2015-06-02T05:41:53Z"
+            },
+            "failure_code": null,
+            "created": "2015-06-02T05:41:53Z"
+        }""")
+
+        recipient = class_.create(
+            name='James Smith',
+            email='secondary@recipient.co',
+            description='Secondary recipient',
+            type='individual',
+            bank_account={
+                'brand': 'test',
+                'name': 'James Smith',
+                'number': '012345'
+            }
+        )
+
+        self.assertTrue(isinstance(recipient, class_))
+        self.assertEqual(recipient.id, 'recp_test')
+        self.assertEqual(recipient.name, 'James Smith')
+        self.assertEqual(recipient.description, 'Secondary recipient')
+        self.assertEqual(recipient.type, 'individual')
+
+        bank_account = recipient.bank_account
+        bank_account_class_ = self._getBankAccountClass()
+        self.assertTrue(isinstance(bank_account, bank_account_class_))
+        self.assertEqual(bank_account.brand, 'test')
+        self.assertEqual(bank_account.last_digits, '2345')
+        self.assertEqual(bank_account.name, 'James Smith')
+        self.assertRequest(
+            api_call,
+            'https://api.omise.co/recipients',
+            {
+                'name': 'James Smith',
+                'email': 'secondary@recipient.co',
+                'description': 'Secondary recipient',
+                'type': 'individual',
+                'bank_account': {
+                    'brand': 'test',
+                    'name': 'James Smith',
+                    'number': '012345'
+                }
+            }
+        )
+
+    @mock.patch('requests.get')
+    def test_retrieve(self, api_call):
+        class_ = self._getTargetClass()
+        self.mockResponse(api_call, """{
+            "object": "recipient",
+            "id": "recp_test",
+            "livemode": false,
+            "location": "/recipients/recp_test",
+            "verified": false,
+            "active": false,
+            "name": "James Smith",
+            "email": "secondary@recipient.co",
+            "description": "Secondary recipient",
+            "type": "individual",
+            "tax_id": "1234567890",
+            "bank_account": {
+                "object": "bank_account",
+                "brand": "test",
+                "last_digits": "2345",
+                "name": "James Smith",
+                "created": "2015-06-02T05:41:53Z"
+            },
+            "failure_code": null,
+            "created": "2015-06-02T05:41:53Z"
+        }""")
+
+        recipient = class_.retrieve('recp_test')
+        self.assertTrue(isinstance(recipient, class_))
+        self.assertFalse(recipient.verified)
+        self.assertFalse(recipient.active)
+        self.assertEqual(recipient.id, 'recp_test')
+        self.assertEqual(recipient.name, 'James Smith')
+        self.assertEqual(recipient.description, 'Secondary recipient')
+        self.assertEqual(recipient.tax_id, '1234567890')
+        self.assertEqual(recipient.type, 'individual')
+
+        bank_account_class_ = self._getBankAccountClass()
+        bank_account = recipient.bank_account
+        self.assertTrue(isinstance(bank_account, bank_account_class_))
+        self.assertEqual(bank_account.brand, 'test')
+        self.assertEqual(bank_account.last_digits, '2345')
+        self.assertEqual(bank_account.name, 'James Smith')
+
+        self.assertRequest(
+            api_call,
+            'https://api.omise.co/recipients/recp_test')
+
+        self.mockResponse(api_call, """{
+            "object": "recipient",
+            "id": "recp_test",
+            "livemode": false,
+            "location": "/recipients/recp_test",
+            "verified": false,
+            "active": false,
+            "name": "Foobar Baz",
+            "email": "secondary@recipient.co",
+            "description": "Secondary recipient",
+            "type": "individual",
+            "tax_id": "1234567890",
+            "bank_account": {
+                "object": "bank_account",
+                "brand": "test",
+                "last_digits": "2345",
+                "name": "James Smith",
+                "created": "2015-06-02T05:41:53Z"
+            },
+            "failure_code": null,
+            "created": "2015-06-02T05:41:53Z"
+        }""")
+
+        recipient.reload()
+        self.assertEqual(recipient.name, 'Foobar Baz')
+
+    @mock.patch('requests.get')
+    def test_retrieve_no_args(self, api_call):
+        class_ = self._getTargetClass()
+        collection_class_ = self._getCollectionClass()
+        self.mockResponse(api_call, """{
+            "object": "list",
+            "from": "1970-01-01T07:00:00+07:00",
+            "to": "2015-06-02T05:41:53+07:00",
+            "offset": 0,
+            "limit": 20,
+            "total": 1,
+            "data": [
+                {
+                    "object": "recipient",
+                    "id": "recp_test",
+                    "livemode": false,
+                    "location": "/recipients/recp_test",
+                    "verified": false,
+                    "active": false,
+                    "name": "Foobar Baz",
+                    "email": "secondary@recipient.co",
+                    "description": "Secondary recipient",
+                    "type": "individual",
+                    "tax_id": "1234567890",
+                    "bank_account": {
+                        "object": "bank_account",
+                        "brand": "test",
+                        "last_digits": "2345",
+                        "name": "James Smith",
+                        "created": "2015-06-02T05:41:53Z"
+                    },
+                    "failure_code": null,
+                    "created": "2015-06-02T05:41:53Z"
+                }
+            ]
+        }""")
+
+        recipients = class_.retrieve()
+        self.assertTrue(isinstance(recipients, collection_class_))
+        self.assertTrue(isinstance(recipients[0], class_))
+        self.assertTrue(recipients[0].id, 'recp_test')
+        self.assertTrue(recipients[0].name, 'Foobar Baz')
+        self.assertRequest(api_call, 'https://api.omise.co/recipients')
+
+    @mock.patch('requests.patch')
+    def test_update(self, api_call):
+        recipient = self._makeOne()
+        class_ = self._getTargetClass()
+        self.mockResponse(api_call, """{
+            "object": "recipient",
+            "id": "recp_test",
+            "livemode": false,
+            "location": "/recipients/recp_test",
+            "verified": false,
+            "active": false,
+            "name": "Foobar Baz",
+            "email": "secondary@recipient.co",
+            "description": "Secondary recipient",
+            "type": "individual",
+            "tax_id": "1234567890",
+            "bank_account": {
+                "object": "bank_account",
+                "brand": "test",
+                "last_digits": "2345",
+                "name": "James Smith",
+                "created": "2015-06-02T05:41:53Z"
+            },
+            "failure_code": null,
+            "created": "2015-06-02T05:41:53Z"
+        }""")
+
+        self.assertTrue(isinstance(recipient, class_))
+        self.assertEqual(recipient.name, 'James Smith')
+        recipient.name = 'Foobar Baz'
+        recipient.update()
+
+        self.assertEqual(recipient.name, 'Foobar Baz')
+        self.assertRequest(
+            api_call,
+            'https://api.omise.co/recipients/recp_test',
+            {'name': 'Foobar Baz'}
+        )
+
+    @mock.patch('requests.delete')
+    def test_destroy(self, api_call):
+        recipient = self._makeOne()
+        class_ = self._getTargetClass()
+        self.mockResponse(api_call, """{
+            "object": "recipient",
+            "id": "recp_test",
+            "livemode": false,
+            "deleted": true
+        }""")
+
+        self.assertTrue(isinstance(recipient, class_))
+        self.assertEqual(recipient.id, 'recp_test')
+
+        recipient.destroy()
+        self.assertTrue(recipient.destroyed)
+        self.assertRequest(
+            api_call,
+            'https://api.omise.co/recipients/recp_test'
+        )
 
 
 class RefundTest(_ResourceMixin):

--- a/omise/test/__init__.py
+++ b/omise/test/__init__.py
@@ -1111,7 +1111,7 @@ class CollectionTest(_ResourceMixin):
         self.assertEqual(collection.retrieve('acct_test_2').id, 'acct_test_2')
         self.assertEqual(collection.retrieve('acct_test_3').id, 'acct_test_3')
         self.assertEqual(collection.retrieve('acct_test_4').id, 'acct_test_4')
-        self.assertIsNone(collection.retrieve('acct_test_5'))
+        self.assertEqual(collection.retrieve('acct_test_5'), None)
 
     def test_retrieve_no_args(self):
         collection = self._makeOne()
@@ -1473,7 +1473,7 @@ class DisputeTest(_ResourceMixin):
         self.assertEqual(dispute.currency, 'thb')
         self.assertEqual(dispute.status, 'pending')
         self.assertEqual(dispute.charge, 'chrg_test')
-        self.assertIsNone(dispute.message)
+        self.assertEqual(dispute.message, None)
 
         self.assertRequest(
             api_call,
@@ -1581,7 +1581,7 @@ class DisputeTest(_ResourceMixin):
         }""")
 
         self.assertTrue(isinstance(dispute, class_))
-        self.assertIsNone(dispute.message)
+        self.assertEqual(dispute.message, None)
         dispute.message = 'Foobar Baz'
         dispute.update()
 
@@ -1899,7 +1899,7 @@ class RefundTest(_ResourceMixin):
         class_ = self._getTargetClass()
 
         self.assertTrue(isinstance(refund, class_))
-        self.assertIsNone(refund.transaction)
+        self.assertEqual(refund.transaction, None)
 
         self.mockResponse(api_call, """{
             "object": "refund",
@@ -1999,7 +1999,7 @@ class TransferTest(_ResourceMixin):
         self.assertFalse(transfer.paid)
         self.assertEqual(transfer.id, 'trsf_test')
         self.assertEqual(transfer.amount, 100000)
-        self.assertIsNone(transfer.transaction)
+        self.assertEqual(transfer.transaction, None)
         self.assertRequest(api_call, 'https://api.omise.co/transfers/trsf_test')
 
         self.mockResponse(api_call, """{


### PR DESCRIPTION
This pull request adds support for these new APIs:

* [Bank Account](https://docs.omise.co/api/bank_account)
* [Disputes](https://docs.omise.co/api/disputes)
* [Recipients](https://docs.omise.co/api/recipients)

As well as changing the HTTP payload from form-encoded data into JSON.