### PR TITLE
Ensure JSON payload is sorted by keys

### DIFF
--- a/omise/__init__.py
+++ b/omise/__init__.py
@@ -197,7 +197,7 @@ class Request(object):
     def _build_payload(self, payload):
         if payload is None:
             payload = {}
-        return json.dumps(payload)
+        return json.dumps(payload, sort_keys=True)
 
     def _build_headers(self, headers):
         if headers is None:

--- a/omise/test/__init__.py
+++ b/omise/test/__init__.py
@@ -42,7 +42,7 @@ class _RequestAssertable(object):
             headers = mock.ANY
         api_call.assert_called_with(
             url,
-            data=json.dumps(data),
+            data=json.dumps(data, sort_keys=True),
             headers=headers,
             auth=(mock.ANY, ''),
             verify=mock.ANY)


### PR DESCRIPTION
To make the payload more determinable and fix randomly failed tests in some environment.