### PR TITLE
Allow retrieve customer list

### DIFF
--- a/omise/__init__.py
+++ b/omise/__init__.py
@@ -840,14 +840,18 @@ class Customer(_MainResource, Base):
                          kwargs))
 
     @classmethod
-    def retrieve(cls, customer_id):
+    def retrieve(cls, customer_id=None):
         """Retrieve the customer details for the given :param:`customer_id`.
 
         :param customer_id: a customer id to retrieve.
         :type customer_id: str
         :rtype: Customer
         """
-        return _as_object(cls._request('get', cls._instance_path(customer_id)))
+        if customer_id:
+            return _as_object(
+                cls._request('get',
+                             cls._instance_path(customer_id)))
+        return _as_object(cls._request('get', cls._collection_path()))
 
     def reload(self):
         """Reload the customer details.

--- a/omise/test/__init__.py
+++ b/omise/test/__init__.py
@@ -1618,6 +1618,66 @@ class CustomerTest(_ResourceMixin):
         self.assertEqual(customer.email, 'john.smith@example.com')
         self.assertRequest(api_call, 'https://api.omise.co/customers/cust_test')
 
+    @mock.patch('requests.get')
+    def test_retrieve_no_args(self, api_call):
+        class_ = self._getTargetClass()
+        collection_class_ = self._getCollectionClass()
+        self.mockResponse(api_call, """{
+            "object": "list",
+            "from": "1970-01-01T07:00:00+07:00",
+            "to": "2014-10-27T11:36:24+07:00",
+            "offset": 0,
+            "limit": 20,
+            "total": 1,
+            "data": [
+                {
+                    "object": "customer",
+                    "id": "cust_test",
+                    "livemode": false,
+                    "location": "/customers/cust_test",
+                    "default_card": "card_test",
+                    "email": "john.smith@example.com",
+                    "description": "John Doe (id: 30)",
+                    "created": "2014-10-24T08:26:46Z",
+                    "cards": {
+                        "object": "list",
+                        "from": "1970-01-01T07:00:00+07:00",
+                        "to": "2014-10-24T15:32:31+07:00",
+                        "offset": 0,
+                        "limit": 20,
+                        "total": 1,
+                        "order": null,
+                        "data": [
+                            {
+                                "object": "card",
+                                "id": "card_test",
+                                "livemode": false,
+                                "location": "/customers/cust_test/cards/card_test",
+                                "country": "",
+                                "city": null,
+                                "postal_code": null,
+                                "financing": "",
+                                "last_digits": "4242",
+                                "brand": "Visa",
+                                "expiration_month": 9,
+                                "expiration_year": 2017,
+                                "fingerprint": "098f6bcd4621d373cade4e832627b4f6",
+                                "name": "Test card",
+                                "created": "2014-10-24T08:26:07Z"
+                            }
+                        ],
+                        "location": "/customers/cust_test/cards"
+                    }
+                }
+            ]
+        }""")
+
+        customers = class_.retrieve()
+        self.assertTrue(isinstance(customers, collection_class_))
+        self.assertTrue(isinstance(customers[0], class_))
+        self.assertTrue(customers[0].email, 'john.smith@example.com')
+        self.assertRequest(api_call, 'https://api.omise.co/customers')
+
     @mock.patch('requests.patch')
     def test_update(self, api_call):
         customer = self._makeOne()


### PR DESCRIPTION
Right now, customer can't call `omise.Customer.retrieve()` (call retrieve in Customer class without argument). 
This PR will set `customer_id=None` in default param so they can get Customer collection then.