### PR TITLE
Prepare for 0.9.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
   - '3.4'
   - '3.5'
   - '3.6'
+  - '3.7'
+  - '3.8'
 
 install: 'pip install -e .'
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 script: nosetests
 python:
   - '2.7'
-  - '3.4'
   - '3.5'
   - '3.6'
   - '3.7'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.9.0] - 2020-08-03
+
+Please upgrade to this version before 20 October 2020.
+After this date, the certificate pinned on older versions will expire and prevent this library from functioning.
+
+* [Changed] Added support 3.7 and 3.8
+* [Changed] Removed support for 3.3
+* [Changed] Return resource lists as lazy collections
+
 ## [0.8.1] - 2018-05-21
 
 This version fixes Schedule API getting wrong response when it destroyed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Please upgrade to this version before 20 October 2020.
 After this date, the certificate pinned on older versions will expire and prevent this library from functioning.
 
 * [Changed] Added support 3.7 and 3.8
-* [Changed] Removed support for 3.3
+* [Changed] Removed support for 3.3 and 3.4
 * [Changed] Return resource lists as lazy collections
 
 ## [0.8.1] - 2018-05-21

--- a/README.md
+++ b/README.md
@@ -3,11 +3,8 @@
 [![Build Status](https://travis-ci.org/omise/omise-python.svg?branch=master)](https://travis-ci.org/omise/omise-python)
 [![Python Versions](https://img.shields.io/pypi/pyversions/omise.svg?style=flat-square)](https://pypi.python.org/pypi/omise/)
 [![PyPi Version](https://img.shields.io/pypi/v/omise.svg?style=flat-square)](https://pypi.python.org/pypi/omise/)
-[![](https://img.shields.io/badge/discourse-forum-1a53f0.svg?style=flat-square&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAAAXNSR0IArs4c6QAAAAlwSFlzAAALEwAACxMBAJqcGAAAAVlpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IlhNUCBDb3JlIDUuNC4wIj4KICAgPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4KICAgICAgPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIKICAgICAgICAgICAgeG1sbnM6dGlmZj0iaHR0cDovL25zLmFkb2JlLmNvbS90aWZmLzEuMC8iPgogICAgICAgICA8dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPgogICAgICA8L3JkZjpEZXNjcmlwdGlvbj4KICAgPC9yZGY6UkRGPgo8L3g6eG1wbWV0YT4KTMInWQAAAqlJREFUKBU9UVtLVFEU%2FvY%2B27mPtxl1dG7HbNRx0rwgFhJBPohBL9JTZfRQ0YO9RU%2FVL6iHCIKelaCXqIewl4gEBbEyxSGxzKkR8TbemmbmnDlzVvsYtOHbey1Y317fWh8DwCVMCfSHww3ElCs7CjuzbOcNIaEo9SbtlDRjZiNPY%2BvrqSWrTh7l3yPvrmh0KBZW59HcREjEqcGpElAuESRxopU648dTwfrIyH%2BCFXSH1cFgJLqHlma6443SG0CfqYY2NZjQnkV8eiMgP6ijjnizHglErlocdl5VA0mT3v102dseL2W14cYM99%2B9XGY%2FlQArd8Mo6JhbSJUePHytvf2UdnW0qen93cKQ4nWXX1%2FyOkZufsuZN0L7PPzkthDDZ4FQLajSA6XWR8HWIK861sCfj68ggGwl83mzfMclBmAQ%2BktrqBu9wOhcD%2BB0ErSiFFyEkdcYhKD27mal9%2F5FY36b4BB%2FTvO8XdQhlUe11F3WG2fc7QLlC8wai3MGGQCGDkcZQyymCqAPSmati3s45ygWseeqADwuWS%2F3wGS5hClDMMstxvJFHQuGU26yHsY6iHtL0sIaOyZzB9hZz0hHZW71kySSl6LIJlSgj5s5LO6VG53aFgpOfOFCyoFmYsOS5HZIaxVwKYsLSbJJn2kfU%2BlNdms5WMLqQRklX0FX26eFRnKYwzX0XRsgR0uUrWxplM7oqPIq8r8cZrdLNLqaABayxZMTTx2HVfglbP4xkcvqZEMNfmglevRi1ny5mGfJfTuQiBEq%2FMBvG0NqDh2TY47sbtJAuO%2Fe9%2Fn3STRFosm2WIxsFSFrFUfwHb11JNBNcaZSp8yb%2FEhHW3suWRNZRzDGvxb0oifk5lmnX2V2J2dEJkX1Q0baZ1MvYXPXHvhAga7x9PTEyj8a%2BF%2BXbxiTn78bSQAAAABJRU5ErkJggg%3D%3D)](https://forum.omise.co)
 
-Please pop onto our [community forum](https://forum.omise.co) or contact
-[support@omise.co](mailto:support@omise.co) if you have any question regarding this
-library and the functionality it provides.
+Please raise an issue or contact [support@omise.co](mailto:support@omise.co) if you have any question regarding this library and the functionality it provides.
 
 ## Installation
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError:
     from distutils.core import setup
 
 setup(name='omise',
-      version='0.8.1',
+      version='0.9.0',
       description='Omise Python client',
       author='Omise',
       author_email='support@omise.co',


### PR DESCRIPTION
Please upgrade to this version before 20 October 2020.
After this date, the certificate pinned on older versions will expire and prevent this library from functioning.

* [Changed] Added support 3.7 and 3.8
* [Changed] Removed support for 3.3
* [Changed] Return resource lists as lazy collections