### PR TITLE
add Card.retrieve(customer_id, card_id) with request from API

### DIFF
--- a/omise/__init__.py
+++ b/omise/__init__.py
@@ -448,10 +448,25 @@ class Card(_MainResource, Base):
         '4242'
     """
 
-
     @classmethod
     def _collection_path(cls):
         return 'cards'
+
+    @classmethod
+    def _instance_path(cls, customer_id, card_id):
+        return ('customers', customer_id, 'cards', card_id)
+
+    @classmethod
+    def retrieve(cls, customer_id, card_id):
+        """Retrieve the card details for the given :param:`card_id`.
+
+        :param customer_id: a customer id of card id.
+        :type customer_id: str
+        :param card_id: a card id to retrieve.
+        :type card_id: str
+        :rtype: Card
+        """
+        return _as_object(cls._request('get', cls._instance_path(customer_id, card_id)))
 
     def reload(self):
         """Reload the card details.

--- a/omise/test/test_card.py
+++ b/omise/test/test_card.py
@@ -64,6 +64,34 @@ class CardTest(_ResourceMixin, unittest.TestCase):
             'https://api.omise.co/customers/cust_test/cards/card_test'
         )
 
+    @mock.patch('requests.get')
+    def test_retrieve(self, api_call):
+        class_ = self._getTargetClass()
+
+        self.mockResponse(api_call, """{
+            "object": "card",
+            "id": "card_test",
+            "livemode": false,
+            "location": "/customers/cust_test/cards/card_test",
+            "country": "",
+            "city": "Bangkok",
+            "postal_code": "10310",
+            "financing": "",
+            "last_digits": "4242",
+            "brand": "Visa",
+            "expiration_month": 12,
+            "expiration_year": 2018,
+            "fingerprint": "098f6bcd4621d373cade4e832627b4f6",
+            "name": "Somchai Prasert",
+            "created": "2014-10-21T04:04:12Z"
+        }""")
+
+        card = class_.retrieve('cust_test', 'card_test')
+        self.assertTrue(isinstance(card, class_))
+        self.assertEqual(card.id, 'card_test')
+        self.assertEqual(card.name, 'Somchai Prasert')
+        self.assertRequest(api_call, 'https://api.omise.co/customers/cust_test/cards/card_test')
+
     @mock.patch('requests.patch')
     def test_update(self, api_call):
         card = self._makeOne()


### PR DESCRIPTION
Replaces https://github.com/omise/omise-python/pull/21

- [x] Adds one-line card retrieval on Card
- [x] Adds test for above

Previously (still works)

```
customer = omise.Customer.retrieve("cust_test_no1t4tnemucod0e51mo")
card = customer.cards.retrieve("card_test_no1t4tnemucod0e51mo")
```

Now

```
card = omise.Card.retrieve("cust_test_no1t4tnemucod0e51mo", "card_test_no1t4tnemucod0e51mo")
```

Thanks @crosalot!
