### PR TITLE
Allow access to metadata

### DIFF
--- a/omise/__init__.py
+++ b/omise/__init__.py
@@ -103,7 +103,7 @@ def _as_object(data):
     if isinstance(data, list):
         return [_as_object(i) for i in data]
     elif isinstance(data, dict):
-        class_ = _get_class_for(data['object'])
+        class_ = _get_class_for(data.get('object'))
         if not class_:
             class_ = Base
         return class_.from_data(data)

--- a/omise/test/test_charge.py
+++ b/omise/test/test_charge.py
@@ -268,6 +268,9 @@ class ChargeTest(_ResourceMixin, unittest.TestCase):
             "amount": 100000,
             "currency": "thb",
             "description": "Order-384",
+            "metadata": {
+                "order_id": "384"
+            },
             "capture": false,
             "authorized": true,
             "reversed": false,
@@ -314,6 +317,7 @@ class ChargeTest(_ResourceMixin, unittest.TestCase):
         self.assertEqual(charge.amount, 100000)
         self.assertEqual(charge.currency, 'thb')
         self.assertEqual(charge.description, 'Order-384')
+        self.assertEqual(charge.metadata.order_id, '384')
         self.assertEqual(charge.ip, '127.0.0.1')
         self.assertEqual(charge.card.id, 'card_test')
         self.assertEqual(charge.card.last_digits, '4242')

--- a/omise/test/test_transfer.py
+++ b/omise/test/test_transfer.py
@@ -74,6 +74,9 @@ class TransferTest(_ResourceMixin, unittest.TestCase):
             "paid": false,
             "amount": 100000,
             "currency": "thb",
+            "metadata": {
+                "recipient_name": "Somchai"
+            },
             "failure_code": null,
             "failure_message": null,
             "transaction": null,
@@ -87,6 +90,7 @@ class TransferTest(_ResourceMixin, unittest.TestCase):
         self.assertFalse(transfer.paid)
         self.assertEqual(transfer.id, 'trsf_test')
         self.assertEqual(transfer.amount, 100000)
+        self.assertEqual(transfer.metadata.recipient_name, 'Somchai')
         self.assertEqual(transfer.transaction, None)
         self.assertRequest(api_call, 'https://api.omise.co/transfers/trsf_test')
 


### PR DESCRIPTION
### Summary
- [x] Use [dict.get](https://docs.python.org/3/library/stdtypes.html#dict.get) to check whether _key_ is in the dictionary before getting the value of _key_ to prevent `KeyError`. This should fix #52.
```python
>>> transfer.metadata.recipient_name
Traceback (most recent call last):
  File "/Users/chanapa/Downloads/projects/omise-python/omise/__init__.py", line 147, in __getattr__
    return _as_object(value)
  File "/Users/chanapa/Downloads/projects/omise-python/omise/__init__.py", line 106, in _as_object
    class_ = _get_class_for(data['object'])
KeyError: 'object'
```
- [x] Add test

### QA
You should be able to access metadata.

1. Create a transfer with metadata.
```python
transfer = omise.Transfer.create(
	amount = 100000,
	metadata = dict(
		recipient_id = '0001',
		recipient_name = 'Somchai'
	)
)
```

2. Access metadata.
```python
>>> transfer.id
'trsf_test_5n6maxqnnscx4046wqn'
>>> transfer.metadata.recipient_name
'Somchai'
```