### PR TITLE
[ENGA3-297]: Fixed the issue of logging secret key in clear text.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# Order is important. The last matching pattern has the most precedence.
+# So if a pull request only touches javascript files, only these owners
+# will be requested to review.
+# example: *.js    @octocat @github/js
+
+# These owners will be the default owners for everything in the repo.
+* @aashishgurung @ajzkk

--- a/omise/request.py
+++ b/omise/request.py
@@ -85,7 +85,11 @@ class Request(object):
         request_headers = self._build_headers(headers)
 
         logger.info('Sending HTTP request: %s %s', method.upper(), request_path)
-        logger.debug('Authorization: %s', self.api_key)
+
+        # Replacing characters with * other than the first 4 characters
+        display_key = self.api_key[:4] + (len(self.api_key) - 4)*'*'
+
+        logger.debug('Authorization: %s', display_key)
         logger.debug('Payload: %s', request_payload)
         logger.debug('Headers: %s', request_headers)
 


### PR DESCRIPTION
### Objective
Fixed the issue of logging secret key in clear text.

Jira Ticket: [#297](https://opn-ooo.atlassian.net/browse/ENGA3-297)

### Description
The key to be displayed is stored in a new variable `display_key`. It will store the first 4 character in plain text and remaining characters are replaced by `*`.

### Environments
- Python: 3.10.6
- Omise Python: 0.11.0