### PR TITLE
Removed logging secret key in clear text

### DIFF
--- a/omise/request.py
+++ b/omise/request.py
@@ -85,7 +85,6 @@ class Request(object):
         request_headers = self._build_headers(headers)
 
         logger.info('Sending HTTP request: %s %s', method.upper(), request_path)
-        logger.debug('Authorization: %s', self.api_key)
         logger.debug('Payload: %s', request_payload)
         logger.debug('Headers: %s', request_headers)
 
@@ -108,7 +107,6 @@ class Request(object):
         request_headers = self._build_file_header(headers)
 
         logger.info('Sending HTTP request: %s %s', method.upper(), request_path)
-        logger.debug('Authorization: %s', self.api_key)
         logger.debug('Files: %s', request_files)
         logger.debug('Headers: %s', request_headers)
 


### PR DESCRIPTION
I would suggest the deletion of the two code lines that log the secret key in clear text.

in link with H1 report [1662194](https://hackerone.com/reports/1662194) and #55 