### PR TITLE
Remove testing on EoL Python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
+        python-version: [2.7, 3.7, 3.8, 3.9, 3.10, 3.11]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ RUN pyenv install 3.6.10
 RUN pyenv install 3.7.6
 RUN pyenv install 3.8.1
 RUN pyenv install 3.9.1
-RUN pyenv global 3.9.1 3.8.1 3.7.6 3.6.10 2.7.17
+RUN pyenv install 3.10.9
+RUN pyenv install 3.11.1
+RUN pyenv global 3.11.1 3.10.9 3.9.1 3.8.1 3.7.6 3.6.10 2.7.17
 
 ## run tests
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,11 @@ easy_install omise
 The Omise Python client officially supports the following Python versions:
 
 * Python 2.7
-* Python 3.6
 * Python 3.7
 * Python 3.8
 * Python 3.9
+* Python 3.10
+* Python 3.11
 
 Any versions not listed here _may_ work but they are not automatically tested.
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36, py37, py38, py39
+envlist = py27, py37, py38, py39, py310, py311
 
 [testenv]
 commands = python setup.py test -q


### PR DESCRIPTION
The GitHub Actions workflows for testing this library fail because EoL Python versions are not available. Removing these old versions so that at GitHub Actions only supported versions of Python are tested.

* Add 3.10, 3.11, remove 3.6.
* Remove 2.7 on GitHub Actions workflow.