### PR TITLE
Replace unowned domain

### DIFF
--- a/omise/__init__.py
+++ b/omise/__init__.py
@@ -279,7 +279,7 @@ class Account(_MainResource, Base):
             >>> import omise
             >>> omise.api_secret = 'skey_test_4xs8breq3htbkj03d2x'
             >>> account = omise.Account.retrieve()
-            >>> account.update(webhook_uri='https://omise-flask-example.herokuapp.com/webhook')
+            >>> account.update(webhook_uri='https://omise.co/webhook')
             <Account id='account_test_5kms3d70v77fs5c37v6' at 0x108cec240>
 
         :param \*\*kwargs: arguments to update an account.

--- a/omise/test/test_account.py
+++ b/omise/test/test_account.py
@@ -79,8 +79,8 @@ class AccountTest(_ResourceMixin, unittest.TestCase):
           "auto_activate_recipients": true,
           "chain_enabled": true,
           "zero_interest_installments": true,
-          "chain_return_uri": "https://omise-flask-example.herokuapp.com",
-          "webhook_uri": "https://omise-flask-example.herokuapp.com/webhook",
+          "chain_return_uri": "https://omise.co",
+          "webhook_uri": "https://omise.co/webhook",
           "metadata_export_keys": {
             "charge": [
               "color",


### PR DESCRIPTION
Replace unowned domain `omise-flask-example.herokuapp.com` in `chain_return_uri` and `webhook_uri` with  `omise.co`