### PR TITLE
Fix name collision in charge schedule function

### DIFF
--- a/omise/__init__.py
+++ b/omise/__init__.py
@@ -835,7 +835,7 @@ class Charge(_MainResource, Base):
         return LazyCollection(self._nested_object_path(Event))
 
     @classmethod
-    def schedule(cls):
+    def list_schedules(cls):
         """Retrieve all charge schedules.
 
         :rtype: Schedule
@@ -846,6 +846,7 @@ class Charge(_MainResource, Base):
         return _as_object(
             cls._request('get',
                          ('charges', 'schedules',)))
+
 
 
 class Collection(Base):

--- a/omise/test/test_charge.py
+++ b/omise/test/test_charge.py
@@ -1060,7 +1060,7 @@ class ChargeTest(_ResourceMixin, unittest.TestCase):
         )
 
     @mock.patch('requests.get')
-    def test_schedule(self, api_call):
+    def test_list_schedules(self, api_call):
         class_ = self._getTargetClass()
         collection_class_ = self._getCollectionClass()
         self.mockResponse(api_call, """{
@@ -1124,7 +1124,7 @@ class ChargeTest(_ResourceMixin, unittest.TestCase):
             ]
         }""")
 
-        schedules = class_.schedule()
+        schedules = class_.list_schedules()
         self.assertTrue(isinstance(schedules, collection_class_))
         self.assertEqual(schedules.total, 1)
         self.assertEqual(schedules.location, '/charges/schedules')


### PR DESCRIPTION
## Description

Fix naming collision when accessing the `schedule` field in the charge class.